### PR TITLE
Add password reset endpoint

### DIFF
--- a/backend/app/models/auth.py
+++ b/backend/app/models/auth.py
@@ -28,3 +28,12 @@ class UserTokenModel(BaseModel):
     token_type: str
     expires_in: int
     refresh_token: str | None = None
+
+
+class PasswordResetRequestModel(BaseModel):
+    email: str
+
+
+class PasswordResetModel(BaseModel):
+    token: str
+    new_password: str

--- a/backend/app/repositories/user.py
+++ b/backend/app/repositories/user.py
@@ -14,3 +14,14 @@ def create_user(session: Session, data: dict) -> User:
 def get_user_br_column(session: Session, sub: str, column_name: str) -> User | None:
     stmt = select(User).where(getattr(User, column_name) == sub)
     return session.exec(stmt).scalar_one_or_none()
+
+
+def update_user_password(session: Session, email: str, hashed_password: str) -> bool:
+    user = get_user_br_column(session, email, "email")
+    if not user:
+        return False
+    user.password = hashed_password
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return True

--- a/backend/app/services/password_reset.py
+++ b/backend/app/services/password_reset.py
@@ -1,0 +1,34 @@
+import logging
+import os
+
+from app.repositories.user import get_user_br_column, update_user_password
+from app.utils.auth.email_password import (
+    create_password_reset_token,
+    verify_password_reset_token,
+    get_password_hash,
+)
+from sqlmodel import Session
+
+logger = logging.getLogger(__name__)
+FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:3000")
+
+
+def request_password_reset(email: str, session: Session) -> bool:
+    user = get_user_br_column(session, email, "email")
+    if not user:
+        logger.error("Password reset requested for non-existent user: %s", email)
+        return False
+    token = create_password_reset_token(email)
+    reset_url = f"{FRONTEND_URL}/auth/reset-password?token={token}"
+    logger.info("Password reset URL for %s: %s", email, reset_url)
+    print(f"Password reset URL for {email}: {reset_url}")
+    return True
+
+
+def reset_password(token: str, new_password: str, session: Session) -> bool:
+    email = verify_password_reset_token(token)
+    if not email:
+        logger.error("Invalid password reset token")
+        return False
+    hashed = get_password_hash(new_password)
+    return update_user_password(session, email, hashed)


### PR DESCRIPTION
## Summary
- allow requesting password reset and resetting password
- log reset URL to console instead of sending email

## Testing
- `black backend/app/models/auth.py backend/app/repositories/user.py backend/app/utils/auth/email_password.py backend/app/services/password_reset.py backend/app/routers/api/auth.py`
