### PR TITLE
Add password reset functionality

### DIFF
--- a/backend/app/migrations/versions/1c198add08e5_add_password_reset_tokens.py
+++ b/backend/app/migrations/versions/1c198add08e5_add_password_reset_tokens.py
@@ -1,0 +1,45 @@
+"""add password reset tokens table
+
+Revision ID: 1c198add08e5
+Revises: a5cc035d75d6
+Create Date: 2025-05-30 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+import sqlmodel
+from alembic import op
+
+revision: str = "1c198add08e5"
+down_revision: Union[str, None] = "a5cc035d75d6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "password_reset_tokens",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("token_hash", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("expires_at", sa.Float(), nullable=False),
+        sa.Column("used", sa.Boolean(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_password_reset_tokens_token_hash"),
+        "password_reset_tokens",
+        ["token_hash"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_password_reset_tokens_token_hash"),
+        table_name="password_reset_tokens",
+    )
+    op.drop_table("password_reset_tokens")

--- a/backend/app/models/password.py
+++ b/backend/app/models/password.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+
+class PasswordResetRequestModel(BaseModel):
+    email: str
+
+
+class PasswordResetModel(BaseModel):
+    token: str
+    new_password: str

--- a/backend/app/repositories/password_reset.py
+++ b/backend/app/repositories/password_reset.py
@@ -1,0 +1,39 @@
+from datetime import datetime
+from typing import Optional
+
+from sqlmodel import Session, select
+
+from app.schema import PasswordResetToken
+
+
+def create_token(
+    session: Session,
+    user_id: int,
+    token_hash: str,
+    expires_at: datetime,
+) -> PasswordResetToken:
+    token = PasswordResetToken(
+        user_id=user_id,
+        token_hash=token_hash,
+        expires_at=expires_at.timestamp(),
+    )
+    session.add(token)
+    session.commit()
+    session.refresh(token)
+    return token
+
+
+def get_active_token_by_hash(
+    session: Session, token_hash: str
+) -> Optional[PasswordResetToken]:
+    stmt = select(PasswordResetToken).where(
+        PasswordResetToken.token_hash == token_hash,
+        PasswordResetToken.used.is_(False),
+    )
+    return session.exec(stmt).first()
+
+
+def mark_token_used(session: Session, token: PasswordResetToken) -> None:
+    token.used = True
+    session.add(token)
+    session.commit()

--- a/backend/app/routers/api/auth.py
+++ b/backend/app/routers/api/auth.py
@@ -7,6 +7,8 @@ from app.utils.auth.email_password import (
 )
 from fastapi import APIRouter, Depends, Form, HTTPException, status
 from sqlmodel import Session
+from app.models.password import PasswordResetModel, PasswordResetRequestModel
+from app.services.password_reset import request_password_reset, reset_password
 
 router = APIRouter(prefix="/auth")
 
@@ -51,3 +53,21 @@ async def sign_in(
         "expires_in": ACCESS_TOKEN_EXPIRE_MINUTES * 60,
         "refresh_token": None,
     }
+
+
+@router.post("/forgot-password")
+async def forgot_password(
+    data: PasswordResetRequestModel,
+    session: Session = Depends(get_session),
+):
+    request_password_reset(data.email, session)
+    return {"message": "If the email exists, a reset link was sent."}
+
+
+@router.post("/reset-password")
+async def reset_password_endpoint(
+    data: PasswordResetModel,
+    session: Session = Depends(get_session),
+):
+    reset_password(data.token, data.new_password, session)
+    return {"message": "Password updated"}

--- a/backend/app/schema.py
+++ b/backend/app/schema.py
@@ -18,3 +18,14 @@ class User(SQLModel, table=True):
 
 
 metadata = SQLModel.metadata
+
+
+class PasswordResetToken(SQLModel, table=True):
+    __tablename__ = "password_reset_tokens"
+    __table_args__ = {"extend_existing": True}
+
+    id: int | None = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="users.id")
+    token_hash: str = Field(index=True, unique=True)
+    expires_at: float
+    used: bool = Field(default=False)

--- a/backend/app/services/password_reset.py
+++ b/backend/app/services/password_reset.py
@@ -1,0 +1,60 @@
+import hashlib
+import os
+import secrets
+from datetime import datetime, timedelta
+
+from fastapi import HTTPException, status
+from sqlmodel import Session
+
+from app.repositories.password_reset import (
+    create_token,
+    get_active_token_by_hash,
+    mark_token_used,
+)
+from app.repositories.user import get_user_br_column
+from app.schema import User
+from app.utils.auth.email_password import get_password_hash
+
+TOKEN_EXPIRE_MINUTES = 30
+FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:3000")
+
+
+def _hash_token(token: str) -> str:
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+def request_password_reset(email: str, session: Session) -> None:
+    user = get_user_br_column(session, email, "email")
+    if not user:
+        return
+    plain_token = secrets.token_urlsafe(32)
+    token_hash = _hash_token(plain_token)
+    expires_at = datetime.now() + timedelta(minutes=TOKEN_EXPIRE_MINUTES)
+    create_token(session, user.id, token_hash, expires_at)
+    reset_url = f"{FRONTEND_URL}/reset-password?token={plain_token}"
+    print(f"Password reset URL for {email}: {reset_url}")
+
+
+def reset_password(token: str, new_password: str, session: Session) -> None:
+    token_hash = _hash_token(token)
+    token_entry = get_active_token_by_hash(session, token_hash)
+    if not token_entry:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid token",
+        )
+    if token_entry.expires_at < datetime.now().timestamp():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Token expired",
+        )
+    user = session.get(User, token_entry.user_id)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="User not found",
+        )
+    user.password = get_password_hash(new_password)
+    mark_token_used(session, token_entry)
+    session.add(user)
+    session.commit()


### PR DESCRIPTION
## Summary
- allow users to request a password reset
- add token table and migration
- log a reset URL instead of sending mail

## Testing
- `black backend/app/models/password.py backend/app/repositories/password_reset.py backend/app/services/password_reset.py backend/app/routers/api/auth.py backend/app/schema.py backend/app/migrations/versions/1c198add08e5_add_password_reset_tokens.py`
- `uv run fastapi dev --host 0.0.0.0 --port 8000` *(fails: `fastapi` not found)*
- `npm run build` *(fails: connect EHOSTUNREACH)*