### PR TITLE
Add password reset token relationships

### DIFF
--- a/backend/app/schema.py
+++ b/backend/app/schema.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from uuid import UUID, uuid4
 
-from sqlmodel import Field, SQLModel
+from sqlmodel import Field, Relationship, SQLModel
 
 
 class User(SQLModel, table=True):
@@ -15,6 +15,22 @@ class User(SQLModel, table=True):
     password: str | None = Field(nullable=True)
     name: str | None = Field(nullable=True)
     clerk_sub: str = Field(nullable=True, unique=True, index=True)
+
+    password_reset_tokens: list["PasswordResetToken"] = Relationship(
+        back_populates="user"
+    )
+
+
+class PasswordResetToken(SQLModel, table=True):
+    __tablename__ = "password_reset_tokens"
+
+    id: int | None = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="users.id")
+    token: str = Field(index=True)
+    created_at: float = Field(default_factory=lambda: datetime.now().timestamp())
+    expires_at: float
+
+    user: User = Relationship(back_populates="password_reset_tokens")
 
 
 metadata = SQLModel.metadata

--- a/backend/app/services/password_reset.py
+++ b/backend/app/services/password_reset.py
@@ -1,0 +1,36 @@
+from datetime import datetime, timedelta
+from uuid import uuid4
+
+from sqlmodel import Session, select
+
+from app.schema import PasswordResetToken
+
+
+DEFAULT_EXPIRES_SECONDS = 60 * 60  # 1 hour
+
+
+def create_password_reset_token(
+    session: Session, user_id: int, expires_in: int = DEFAULT_EXPIRES_SECONDS
+) -> PasswordResetToken:
+    token = uuid4().hex
+    expires_at = datetime.now().timestamp() + expires_in
+    token_entry = PasswordResetToken(
+        user_id=user_id,
+        token=token,
+        expires_at=expires_at,
+    )
+    session.add(token_entry)
+    session.commit()
+    session.refresh(token_entry)
+    return token_entry
+
+
+def get_user_by_token(session: Session, token: str):
+    stmt = select(PasswordResetToken).where(PasswordResetToken.token == token)
+    token_entry = session.exec(stmt).one_or_none()
+    if token_entry is None:
+        return None
+    if token_entry.expires_at < datetime.now().timestamp():
+        return None
+    user = token_entry.user
+    return user


### PR DESCRIPTION
## Summary
- add Relationship import in schema
- define `PasswordResetToken` model and relationship with `User`
- create password reset service using relationship
- move metadata definition to file bottom

## Testing
- `black app/schema.py app/services/password_reset.py app/services/auth.py`
- `uvicorn main:app --reload --port 8000 --app-dir backend` *(fails: ModuleNotFoundError: No module named 'dotenv')*